### PR TITLE
Fix IOS crash when custom_property_list is not provided as a parameter

### DIFF
--- a/ios/Classes/SwiftFlutterFreshchatPlugin.swift
+++ b/ios/Classes/SwiftFlutterFreshchatPlugin.swift
@@ -53,7 +53,7 @@ public class SwiftFlutterFreshchatPlugin: NSObject, FlutterPlugin {
 
             case SwiftFlutterFreshchatPlugin.METHOD_UPDATE_USER_INFO:
                 let arguments = call.arguments as! [String: Any]
-                let customProperties = arguments["custom_property_list"] as! [String: String]
+                let customProperties = arguments["custom_property_list"] as? [String: String]
                 let user = FreshchatUser.sharedInstance()
                 user?.firstName = arguments["first_name"] as? String
                 user?.lastName = arguments["last_name"] as? String
@@ -63,10 +63,8 @@ public class SwiftFlutterFreshchatPlugin: NSObject, FlutterPlugin {
 
                 Freshchat.sharedInstance().setUser(user)
 
-                if (customProperties != nil) {
-                    for (kind, value) in customProperties {
-                        Freshchat.sharedInstance().setUserPropertyforKey(kind, withValue: value)
-                    }
+                for (kind, value) in customProperties ?? [:] {
+                    Freshchat.sharedInstance().setUserPropertyforKey(kind, withValue: value)
                 }
 
                 result(true)


### PR DESCRIPTION
The application crashes on IOS when optional custom_property_list is not provided as an argument

<img width="1134" alt="Screenshot 2019-09-26 at 22 23 10" src="https://user-images.githubusercontent.com/680494/65763584-07f3c800-e124-11e9-9a2a-971c4020df91.png">
