### PR TITLE
Add method for sending messages

### DIFF
--- a/android/src/main/java/com/freshchat/flutter_freshchat/FlutterFreshchatPlugin.java
+++ b/android/src/main/java/com/freshchat/flutter_freshchat/FlutterFreshchatPlugin.java
@@ -11,6 +11,7 @@ import com.freshchat.consumer.sdk.Freshchat;
 import com.freshchat.consumer.sdk.FreshchatCallbackStatus;
 import com.freshchat.consumer.sdk.FreshchatConfig;
 import com.freshchat.consumer.sdk.FreshchatUser;
+import com.freshchat.consumer.sdk.FreshchatMessage;
 import com.freshchat.consumer.sdk.ConversationOptions;
 import com.freshchat.consumer.sdk.UnreadCountCallback;
 import com.freshchat.consumer.sdk.exception.MethodNotAllowedException;
@@ -32,6 +33,7 @@ public class FlutterFreshchatPlugin implements MethodCallHandler {
     private static final String METHOD_SHOW_FAQS = "showFAQs";
     private static final String METHOD_GET_UNREAD_MESSAGE_COUNT = "getUnreadMsgCount";
     private static final String METHOD_SETUP_PUSH_NOTIFICATIONS = "setupPushNotifications";
+    private static final String METHOD_SEND_MESSAGE = "send";
 
     public static void registerWith(Registrar registrar) {
         final MethodChannel channel = new MethodChannel(registrar.messenger(), "flutter_freshchat");
@@ -146,6 +148,15 @@ public class FlutterFreshchatPlugin implements MethodCallHandler {
             break;
         case METHOD_RESET_USER:
             Freshchat.resetUser(this.application.getApplicationContext());
+            result.success(true);
+            break;
+        case METHOD_SEND_MESSAGE:
+            final String message = call.argument["message"];
+            final String tag = call.argument["tag"];
+            FreshchatMessage freshchatMessage = new FreshchatMessage();
+            freshchatMessage.setTag(channel);
+            freshchatMessage.setMessage(message);
+            Freshchat.sendMessage(this.application.getApplicationContext(), freshchatMessage);
             result.success(true);
             break;
         default:

--- a/ios/Classes/SwiftFlutterFreshchatPlugin.swift
+++ b/ios/Classes/SwiftFlutterFreshchatPlugin.swift
@@ -10,6 +10,7 @@ public class SwiftFlutterFreshchatPlugin: NSObject, FlutterPlugin {
     private static let METHOD_SHOW_FAQS = "showFAQs"
     private static let METHOD_GET_UNREAD_MESSAGE_COUNT = "getUnreadMsgCount"
     private static let METHOD_SETUP_PUSH_NOTIFICATIONS = "setupPushNotifications"
+    private static let METHOD_SEND_MESSAGE = "send"
     private let registrar: FlutterPluginRegistrar
 
     init(registrar: FlutterPluginRegistrar) {
@@ -124,6 +125,12 @@ public class SwiftFlutterFreshchatPlugin: NSObject, FlutterPlugin {
                 Freshchat.sharedInstance().resetUser(completion: { () in
                     result(true)
                 })
+
+            case SwiftFlutterFreshchatPlugin.METHOD_SEND_MESSAGE:
+                let message:String = arguments["message"] ?? ""
+                let tag:String = arguments["tag"] ?? ""
+                let freshchatMessage = FreshchatMessage.init(message: message, andTag: tag)
+                Freshchat.sharedInstance().send(freshchatMessage)
 
             default:
                 result(false)

--- a/ios/Classes/SwiftFlutterFreshchatPlugin.swift
+++ b/ios/Classes/SwiftFlutterFreshchatPlugin.swift
@@ -127,6 +127,7 @@ public class SwiftFlutterFreshchatPlugin: NSObject, FlutterPlugin {
                 })
 
             case SwiftFlutterFreshchatPlugin.METHOD_SEND_MESSAGE:
+                let arguments = call.arguments as! [String: String]
                 let message:String = arguments["message"] ?? ""
                 let tag:String = arguments["tag"] ?? ""
                 let freshchatMessage = FreshchatMessage.init(message: message, andTag: tag)

--- a/lib/src/freshchat.dart
+++ b/lib/src/freshchat.dart
@@ -151,4 +151,16 @@ class FlutterFreshchat {
 
     return result;
   }
+
+  /// Send message
+  static Future<bool> send({@required String message, String tag}) async {
+    final Map<String, dynamic> params = <String, dynamic>{
+      message: message,
+      tag: tag
+    };
+
+    final bool result = await _channel.invokeMethod('send', params);
+
+    return result;
+  }
 }


### PR DESCRIPTION
Flutter package did not have method mappings for sending messages which is supported by underlying native packages.