### PR TITLE
Fixes for some iOS build isses.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,19 +37,7 @@ Add this to your `Strings.xml` located inside `android/src/res/values`
 
 ### IOS
 
-1. If you are using Objective-C in your flutter project then you will need to create a briging header between objective-C and swift to do that follow the steps below:
-
-   > - Bridging Header must be created.
-   > - Open the project with XCode. Then choose File -> New -> File -> Swift File.
-   > - A dialog will be displayed when creating the swift file(Since this file is deleted, any name can be used.).
-   > - XCode will ask you if you wish to create Bridging Header, click yes.
-   > - Make sure you have use_frameworks! in the Runner block, in ios/Podfile。
-   > - Make sure you have SWIFT_VERSION 4.2 selected in you XCode -> Build Settings
-   > - Do flutter clean.
-   > - Go to your ios folder, delete Podfile.lock and Pods folder and then execute pod install --repo-update
-
-2. Add `use_frameworks!` at the top of your Podfile.
-3. Add this to info.plist
+1. Add this to info.plist
    > Starting with iOS 10, Apple requires developers to declare access to privacy-sensitive controls ahead of time.
 
 ```xml
@@ -58,6 +46,16 @@ Add this to your `Strings.xml` located inside `android/src/res/values`
     <key>NSCameraUsageDescription</key>
     <string>To take Images from Camera</string>
 ```
+
+2. If you encounter `non-modular header` error during project build
+
+    ```
+    error: include of non-modular header inside framework module 'flutter_freshchat.FlutterFreshchatPlugin'
+    ```
+
+   > - Manually in xcode update the FreshchatSDK.h to be in the flutter_freshchat target and public.
+   <img width="930" alt="FreshchatSDK_fix" src="https://user-images.githubusercontent.com/40217827/88995177-452a6880-d2a7-11ea-8cbc-2e47ebf62ff8.png">
+   You may have to do this each time your switch or rebuild the xcode project from flutter.
 
 <!-- 4. At this point if you try to build you will get an error something related to duplicate `info.plist` (Note: It's something to do with Freshchat) you can remove this info by following the below instructions:
 
@@ -105,7 +103,7 @@ It has following [FreshchatConfig] properties:
 
 ```dart
 await FlutterFreshchat.init(
-  appID: 'YOUR_APP_ID_HERE', 
+  appID: 'YOUR_APP_ID_HERE',
   appKey: 'YOUR_APP_KEY_HERE',
   domain: 'https://msdk.freshchat.com'
   );

--- a/ios/Classes/FlutterFreshchatPlugin.m
+++ b/ios/Classes/FlutterFreshchatPlugin.m
@@ -1,5 +1,12 @@
 #import "FlutterFreshchatPlugin.h"
+#if __has_include(<flutter_freshchat/flutter_freshchat-Swift.h>)
 #import <flutter_freshchat/flutter_freshchat-Swift.h>
+#else
+// Support project import fallback if the generated compatibility header
+// is not copied when this plugin is created as a library.
+// https://forums.swift.org/t/swift-static-libraries-dont-copy-generated-objective-c-header/19816
+#import "flutter_freshchat-Swift.h"
+#endif
 
 @implementation FlutterFreshchatPlugin
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar>*)registrar {

--- a/ios/Classes/SwiftFlutterFreshchatPlugin.swift
+++ b/ios/Classes/SwiftFlutterFreshchatPlugin.swift
@@ -42,19 +42,19 @@ public class SwiftFlutterFreshchatPlugin: NSObject, FlutterPlugin {
                 let responseExpectationEnabled = arguments["responseExpectationEnabled"] as! Bool
                 let showNotificationBanner = arguments["showNotificationBanner"] as! Bool
                 let notificationSoundEnabled = arguments["notificationSoundEnabled"] as! Bool
-                
+
                 let freshchatConfig = FreshchatConfig.init(appID: appID, andAppKey: appKey)
 
-                freshchatConfig?.gallerySelectionEnabled = gallerySelectionEnabled
-                freshchatConfig?.cameraCaptureEnabled = cameraEnabled
-                freshchatConfig?.teamMemberInfoVisible = teamMemberInfoVisible
-                freshchatConfig?.showNotificationBanner = showNotificationBanner
-                freshchatConfig?.responseExpectationVisible = responseExpectationEnabled
-                freshchatConfig?.notificationSoundEnabled = notificationSoundEnabled
-                freshchatConfig?.domain = domain
+                freshchatConfig.gallerySelectionEnabled = gallerySelectionEnabled
+                freshchatConfig.cameraCaptureEnabled = cameraEnabled
+                freshchatConfig.teamMemberInfoVisible = teamMemberInfoVisible
+                freshchatConfig.showNotificationBanner = showNotificationBanner
+                freshchatConfig.responseExpectationVisible = responseExpectationEnabled
+                freshchatConfig.notificationSoundEnabled = notificationSoundEnabled
+                freshchatConfig.domain = domain
 
                 Freshchat.sharedInstance().initWith(freshchatConfig)
-                
+
                 result(true)
 
             case SwiftFlutterFreshchatPlugin.METHOD_IDENTIFY_USER:
@@ -74,11 +74,11 @@ public class SwiftFlutterFreshchatPlugin: NSObject, FlutterPlugin {
                 let arguments = call.arguments as! [String: Any]
                 let customProperties = arguments["custom_property_list"] as? [String: String]
                 let user = FreshchatUser.sharedInstance()
-                user?.firstName = arguments["first_name"] as? String
-                user?.lastName = arguments["last_name"] as? String
-                user?.phoneNumber  = arguments["phone"] as? String
-                user?.email = arguments["email"] as? String
-                user?.phoneCountryCode = arguments["phone_country_code"] as? String
+                user.firstName = arguments["first_name"] as? String
+                user.lastName = arguments["last_name"] as? String
+                user.phoneNumber  = arguments["phone"] as? String
+                user.email = arguments["email"] as? String
+                user.phoneCountryCode = arguments["phone_country_code"] as? String
 
                 Freshchat.sharedInstance().setUser(user)
 

--- a/ios/flutter_freshchat.podspec
+++ b/ios/flutter_freshchat.podspec
@@ -1,5 +1,5 @@
-  #
-# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
+#
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
 #
 Pod::Spec.new do |s|
   s.name             = 'flutter_freshchat'
@@ -13,11 +13,16 @@ A Flutter plugin for integrating Freshchat in your mobile app.
   s.author           = { 'Fayeed Pawaskar' => 'fayeed@live.com' }
   s.source           = { :git => "https://github.com/freshdesk/freshchat-ios.git", :tag => "3.4.0" }
   s.source_files = 'Classes/**/*'
-  s.public_header_files = 'Classes/**/*.h'
+  # s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'FreshchatSDK'
-  s.frameworks 			 = "Foundation", "AVFoundation", "AudioToolbox", "CoreMedia", "CoreData", "ImageIO", "Photos", "SystemConfiguration", "Security", "WebKit"
-  s.static_framework = true
-  s.ios.deployment_target = '8.0'
-end
+  s.platform = :ios, '8.0'
 
+  # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+  s.swift_version = '4.2'
+
+  s.frameworks = "Foundation", "AVFoundation", "AudioToolbox", "CoreMedia", "CoreData", "ImageIO", "Photos", "SystemConfiguration", "Security", "WebKit"
+  s.dependency 'FreshchatSDK'
+
+  s.static_framework = true
+end


### PR DESCRIPTION
I was unable to build on iOS getting lots of `error: include of non-modular header inside framework module 'flutter_freshchat.FlutterFreshchatPlugin'`

- Update the podspec to include swift, I think this makes xcode generate and use a umbrella header, that will fix Opjective-C and Swift issues. 
- Updated the code to fix swift errors with null safety.
- Added flutter template import fallback to the .m file.
- Manualy in xcode update the FreshchatSDK.h to be in the flutter_freshchat target and public. 
<img width="1401" alt="freshchat" src="https://user-images.githubusercontent.com/40217827/88990073-4c974500-d29a-11ea-9547-e847c29e6642.png"> https://imgur.com/a/BRYZt0R 
  This setup on the SDK is often lost by flutter when rebuilding the project, so you may have to reapply it. (I could not find a way to do it automatically)

After this I can build from xCode or command line with `flutter run`

I'm not a iOS expert, but I think these changes may be very helpful.

Pubspec test
```
  flutter_freshchat:
    git:
      url: https://github.com/GuruJohn/flutter_freshchat.git
```

This might fix some issues people may still be having with https://github.com/fayeed/flutter_freshchat/issues/31